### PR TITLE
Align website and CV content, update Kog role description

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,8 @@
               >
                 Kog
               </a>
-              , working on hardware tailored and optimized LLM architecture.
+              , as pretraining lead for hardware co-designed models focused on
+              extreme inference speed.
             </p>
           </section>
 

--- a/public/cv-fr-morgan-giraud.html
+++ b/public/cv-fr-morgan-giraud.html
@@ -206,6 +206,13 @@ code {
 <div class="page"></div>
 <h2>EXPÉRIENCE PROFESSIONNELLE (classée par date)</h2>
 <div class="container">
+    <h3 class="left">Kog | Ingénieur recherche ML</h3>
+    <div class="right">
+        <em>Oct 2024 – ...</em>
+    </div>
+</div>
+<p>Direction d'une équipe de 3 chercheurs chez <a href="https://www.kog.ai/">Kog</a> avec un rôle de lead préentraînement sur des modèles co-conçus avec le hardware pour une vitesse d'inférence extrême.</p>
+<div class="container">
     <h3 class="left">WoW Studio | Lead technique </h3>
     <div class="right">
         <em>Avr 2022 – Nov 2023</em>

--- a/public/cv-morgan-giraud-short.html
+++ b/public/cv-morgan-giraud-short.html
@@ -214,6 +214,13 @@ code {
 <div class="page"></div>
 <h2>WORK EXPERIENCE (ordered by date)</h2>
 <div class="container">
+    <h3 class="left">Kog | ML research engineer</h3>
+    <div class="right">
+        <em>Oct 2024 – ...</em>
+    </div>
+</div>
+<p>Leading a team of 3 researchers at <a href="https://www.kog.ai/">Kog</a> as pretraining lead for hardware co-designed models focused on extreme inference speed.</p>
+<div class="container">
     <h3 class="left">WoW Studio | Tech lead </h3>
     <div class="right">
         <em>Apr 2022 – Nov 2023</em>

--- a/public/cv-morgan-giraud.html
+++ b/public/cv-morgan-giraud.html
@@ -206,6 +206,17 @@ code {
 <div class="page"></div>
 <h2>WORK EXPERIENCE (ordered by date)</h2>
 <div class="container">
+    <h3 class="left">Kog | ML research engineer</h3>
+    <div class="right">
+        <em>Oct 2024 – ...</em>
+    </div>
+</div>
+<p>Leading a team of 3 researchers at <a href="https://www.kog.ai/">Kog</a> as pretraining lead for hardware co-designed models focused on extreme inference speed.</p>
+<ul>
+<li>Leading pretraining strategy and execution for hardware co-designed model families.</li>
+<li>Driving architecture and optimization experiments to maximize inference throughput.</li>
+</ul>
+<div class="container">
     <h3 class="left">WoW Studio | Tech lead </h3>
     <div class="right">
         <em>Apr 2022 – Nov 2023</em>

--- a/src/cv/cv-fr-morgan-giraud.md
+++ b/src/cv/cv-fr-morgan-giraud.md
@@ -41,6 +41,15 @@ Expériences notables :
 ## EXPÉRIENCE PROFESSIONNELLE (classée par date)
 
 <div class="container">
+    <h3 class="left">Kog | Ingénieur recherche ML</h3>
+    <div class="right">
+        <em>Oct 2024 – ...</em>
+    </div>
+</div>
+
+Direction d'une équipe de 3 chercheurs chez [Kog](https://www.kog.ai/) avec un rôle de lead préentraînement sur des modèles co-conçus avec le hardware pour une vitesse d'inférence extrême.
+
+<div class="container">
     <h3 class="left">WoW Studio | Lead technique </h3>
     <div class="right">
         <em>Avr 2022 – Nov 2023</em>

--- a/src/cv/cv-morgan-giraud-short.md
+++ b/src/cv/cv-morgan-giraud-short.md
@@ -54,6 +54,15 @@ Intensive courses in advanced mathematics and physics, preparing for the highly 
 ## WORK EXPERIENCE (ordered by date)
 
 <div class="container">
+    <h3 class="left">Kog | ML research engineer</h3>
+    <div class="right">
+        <em>Oct 2024 – ...</em>
+    </div>
+</div>
+
+Leading a team of 3 researchers at [Kog](https://www.kog.ai/) as pretraining lead for hardware co-designed models focused on extreme inference speed.
+
+<div class="container">
     <h3 class="left">WoW Studio | Tech lead </h3>
     <div class="right">
         <em>Apr 2022 – Nov 2023</em>

--- a/src/cv/cv-morgan-giraud.md
+++ b/src/cv/cv-morgan-giraud.md
@@ -41,6 +41,18 @@ Notable experiences:
 ## WORK EXPERIENCE (ordered by date)
 
 <div class="container">
+    <h3 class="left">Kog | ML research engineer</h3>
+    <div class="right">
+        <em>Oct 2024 – ...</em>
+    </div>
+</div>
+
+Leading a team of 3 researchers at [Kog](https://www.kog.ai/) as pretraining lead for hardware co-designed models focused on extreme inference speed.
+
+- Leading pretraining strategy and execution for hardware co-designed model families.
+- Driving architecture and optimization experiments to maximize inference throughput.
+
+<div class="container">
     <h3 class="left">WoW Studio | Tech lead </h3>
     <div class="right">
         <em>Apr 2022 – Nov 2023</em>


### PR DESCRIPTION
## Summary
- align current role content between the website and generated CVs
- improve Kog role description to mention pretraining lead responsibilities
- regenerate CV HTML outputs from updated markdown sources

## Changes
- update Kog description in index.html
- add Kog role section to EN CV and short CV markdown sources
- add matching Kog role section to FR CV markdown source
- regenerate public CV HTML files via `yarn build:cv`

## Validation
- run `yarn build:cv`
- run `yarn lint`